### PR TITLE
specify md output encoding as utf-8

### DIFF
--- a/ghidriff/ghidra_diff_engine.py
+++ b/ghidriff/ghidra_diff_engine.py
@@ -1736,11 +1736,11 @@ class GhidraDiffEngine(GhidriffMarkdown, metaclass=ABCMeta):
 
                 # give line ending md despite html so it will render in gists and vscode
                 sxs_diff_path = sxs_output_path / Path('.'.join([name, _clean_func(func_name), 'md']))
-                sxs_diff_path.write_text(sxs_diff_html)
+                sxs_diff_path.write_text(sxs_diff_html, encoding='utf-8')
 
             combined_sxs_diff_html = GhidriffMarkdown.gen_combined_sxs_html_from_pdiff(pdiff)
             combined_sxs_diff_path = sxs_output_path / Path('.'.join([name, 'combined', 'html']))
-            combined_sxs_diff_path.write_text(combined_sxs_diff_html)
+            combined_sxs_diff_path.write_text(combined_sxs_diff_html, encoding='utf-8')
 
         if write_diff:
             self.logger.info(f'Wrote {md_path}')

--- a/ghidriff/ghidra_diff_engine.py
+++ b/ghidriff/ghidra_diff_engine.py
@@ -1713,7 +1713,7 @@ class GhidraDiffEngine(GhidriffMarkdown, metaclass=ABCMeta):
                 max_section_funcs=max_section_funcs,
                 title=md_title)
 
-            with md_path.open('w') as f:
+            with md_path.open('w', encoding='utf-8') as f:
                 f.write(diff_text)
 
         if write_json:


### PR DESCRIPTION
Specify md output encoding as utf-8 to prevent some encoding errors on non-English language systems

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\test\scoop\apps\python311\current\Scripts\ghidriff.exe\__main__.py", line 7, in <module>
  File "C:\Users\test\scoop\apps\python311\current\Lib\site-packages\ghidriff\__main__.py", line 94, in main
    d.dump_pdiff_to_path(diff_name,
  File "C:\Users\test\scoop\apps\python311\current\Lib\site-packages\ghidriff\ghidra_diff_engine.py", line 1716, in dump_pdiff_to_path
    f.write(diff_text)
UnicodeEncodeError: 'cp950' codec can't encode character '\xa9' in position 8649: illegal multibyte sequence
```