### PR TITLE
Use hash tables for FullName:Param matching in SimpleDiff

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "ghidriff",
 	// image from https://github.com/clearbluejar/ghidra-python	
-	"image": "ghcr.io/clearbluejar/ghidra-python:11.2ghidra3.12python-bookworm",
+	"image": "ghcr.io/clearbluejar/ghidra-python:11.2.1ghidra3.12python-bookworm",
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.


### PR DESCRIPTION
This way we can reduce the complexity of the matching phase from O(n^2) to O(n). The original inner loop also didn't break if a match was found. The change can be significant in case of large diffs. 