### PR TITLE
Fix: Initialize called_set and calling_set variables

### DIFF
--- a/ghidriff/markdown.py
+++ b/ghidriff/markdown.py
@@ -817,6 +817,8 @@ pie showData
 
                         ignore_called = False
                         ignore_calling = False
+                        called_set = set()
+                        calling_set = set()
 
                         if len(modified['old']['called']) > 0 and len(modified['new']['called']) > 0:
                             called_set = set(modified['old']['called']).difference(modified['new']['called'])


### PR DESCRIPTION
This PR resolves the issue #126:
- Initialize called_set and calling_set as empty sets to prevent UnboundLocalError
- Ensures variables are always defined before conditional usage

